### PR TITLE
Use pyramid's setup_logging function in env.py

### DIFF
--- a/pyramid_alembic/alembic/+package+/alembic/env.py_tmpl
+++ b/pyramid_alembic/alembic/+package+/alembic/env.py_tmpl
@@ -2,7 +2,6 @@ from __future__ import with_statement
 from alembic import context
 from sqlalchemy import engine_from_config
 from sqlalchemy.engine.base import Engine
-from logging.config import fileConfig
 from pyramid.paster import get_appsettings, setup_logging
 
 # this is the Alembic Config object, which provides


### PR DESCRIPTION
This stops alembic from choking on the extra 'here' or '**file**' variables in pyramid logging configuration.
